### PR TITLE
Quicklaunch read settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Tauri + React + TS</title>
+    <title>Monarch Launcher</title>
   </head>
 
   <body>

--- a/src-tauri/src/monarch_utils/commands.rs
+++ b/src-tauri/src/monarch_utils/commands.rs
@@ -8,7 +8,7 @@ use toml::Table; // Use normal result instead of anyhow when sending to Frontend
 use super::housekeeping::clear_all_cache;
 use super::monarch_credentials::{delete_credentials, set_credentials};
 use super::monarch_logger::get_log_dir;
-use super::monarch_settings::{read_settings, set_default_settings, write_settings};
+use super::monarch_settings::{get_quicklaunch_settings, read_settings, set_default_settings, write_settings};
 use super::monarch_windows::MiniWindow;
 
 #[cfg(target_os = "windows")]
@@ -142,7 +142,14 @@ pub fn delete_password(platform: String, username: String) -> Result<(), String>
 /// lacks support for global shortcuts and makes Monarch hang.
 pub fn quicklaunch_is_enabled() -> bool {
     // First check if quicklaunch is disabled in settings
-    // TODO: Check if quicklaunch is enabled in settings
+    if let Some(quick_settings) = get_quicklaunch_settings() {
+        if quick_settings["enabled"].as_bool().unwrap() == false {
+            return false;
+        }
+    } else { // Error with quicklaunch settings, default to false
+        error!("monarch_utils::commands::init_quicklaunch() get_quicklaunch_settings() returned None! Disabling quicklaunch...");
+        return false;
+    }
 
     // Then check if Monarch is being run under Wayland
     if cfg!(target_os = "linux") {

--- a/src-tauri/src/monarch_utils/monarch_settings.rs
+++ b/src-tauri/src/monarch_utils/monarch_settings.rs
@@ -209,7 +209,7 @@ fn get_default_settings() -> Table {
 
     let mut quicklaunch_settings: Table = Table::new();
     quicklaunch_settings.insert("enabled".to_string(), true.into());
-    quicklaunch_settings.insert("open_shortcut".to_string(), "Super+Enter".into());
+    quicklaunch_settings.insert("open_shortcut".to_string(), "CommandOrControl+Space".into());
     quicklaunch_settings.insert("close_shortcut".to_string(), "Esc".into());
     quicklaunch_settings.insert("size".to_string(), "medium".into());
 

--- a/src/global/types/index.ts
+++ b/src/global/types/index.ts
@@ -19,3 +19,38 @@ export type Collection = {
   name: string;
   gameIds: string[];
 };
+
+// TODO: Let Dre make this better...
+export type MonarchSettings = {
+  monarch: MonarchSetting;
+  quicklaunch: QuicklaunchSetting;
+  steam: SteamSetting;
+  epic: EpicSetting;
+};
+
+export type MonarchSetting = {
+  monarch_home: string;
+  send_logs: boolean;
+  run_on_startup: boolean;
+  start_minimized: boolean;
+  game_folder: string;
+}
+
+export type QuicklaunchSetting = {
+  enabled: boolean;
+  open_shortcut: string;
+  close_shortcut: string;
+  size: string;
+}
+
+export type SteamSetting = {
+  game_folders: string;
+  manage: boolean;
+  username: string;
+}
+
+export type EpicSetting = {
+  game_folders: string;
+  manage: boolean;
+  username: string;
+}

--- a/src/quicklaunch/initShortcuts.ts
+++ b/src/quicklaunch/initShortcuts.ts
@@ -4,6 +4,7 @@ import {
   register,
   unregisterAll,
 } from '@tauri-apps/api/globalShortcut';
+import { MonarchSettings } from '@global/types';
 
 // TODO: PROPER ERROR HANDLING
 const initShortcuts = async () => {
@@ -16,29 +17,25 @@ const initShortcuts = async () => {
   // Define global shortcuts for quicklaunch (proto-typing)
   await unregisterAll();
 
-  const quickLaunchRegistered = await isRegistered('CommandOrControl+Space');
-  const closeRegistered = await isRegistered('Esc');
+  const quicklaunchSettings = await invoke('get_settings') as MonarchSettings;
+
+  const quickLaunchRegistered = await isRegistered(quicklaunchSettings.quicklaunch.open_shortcut);
+  const closeRegistered = await isRegistered(quicklaunchSettings.quicklaunch.close_shortcut);
 
   // Build initial quicklaunch
   await invoke('init_quicklaunch');
 
-  console.log("Finished setting up init_quicklaunch!");
-
   if (!quickLaunchRegistered) {
-    await register('CommandOrControl+Space', async () => {
+    await register(quicklaunchSettings.quicklaunch.open_shortcut, async () => {
       await invoke("show_quicklaunch");
     });
-    console.log("Finished setting up show quicklaunch!");
   }
 
   if (!closeRegistered) {
-    await register('Esc', async () => {
+    await register(quicklaunchSettings.quicklaunch.close_shortcut, async () => {
       await invoke("hide_quicklaunch");
     });
-    console.log("Finished setting up hide quicklaunch!");
   }
-
-  console.log("Finished setting up initShortcuts!");
 };
 
 export default initShortcuts;


### PR DESCRIPTION
Monarch checks if quicklaunch is enabled before starting it, also checks settings for shortcuts instead of hard-coding them.