### PR TITLE
umu-launcher integration

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
  "serde_json",
  "simple-steam-totp",
  "sysinfo",
+ "tar",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -1330,6 +1331,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2502,6 +2515,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.5.0",
  "libc",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -4993,6 +5007,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6828,6 +6853,16 @@ name = "x11rb-protocol"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
+
+[[package]]
+name = "xattr"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
+dependencies = [
+ "libc",
+ "rustix 1.0.8",
+]
 
 [[package]]
 name = "xdg-home"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1.0"
 # Monarch dependencies
 tokio = { version = "1", features = ["full"] }
 toml = { version = "0.8.11", features = ["preserve_order"] }
-reqwest = "0.11.0"
+reqwest = { version = "0.11.0", features = ["blocking"] }
 scraper = "0.19.0"
 tracing = { version = "0.1.41", features = [
   "max_level_trace",
@@ -42,6 +42,7 @@ tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-shell = "2"
 futures = { version = "0.3", default-features = false, features = ["executor"] }
+tar = "0.4.44"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 webkit2gtk = "2.0.1" # if tauri build fails, make sure to match this version to what we have in tauri

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,7 +12,7 @@ use futures::executor;
 use monarch_games::commands::{
     download_game, get_home_recomendations, get_library, launch_game, move_game_to_monarch,
     open_store, proton_versions, refresh_library, remove_game, search_games, update_game,
-    update_game_properties, manual_add_game, manual_remove_game
+    update_game_properties, manual_add_game, manual_remove_game, umu_is_installed, install_umu,
 };
 use monarch_library::commands::{
     create_collection, delete_collection, get_collections, update_collection,
@@ -100,6 +100,8 @@ fn main() {
             manual_add_game,
             manual_remove_game,
             zoom_window,
+            umu_is_installed,
+            install_umu,
         ])
         .setup(|app| {
             #[cfg(desktop)]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,7 +12,7 @@ use futures::executor;
 use monarch_games::commands::{
     download_game, get_home_recomendations, get_library, launch_game, move_game_to_monarch,
     open_store, proton_versions, refresh_library, remove_game, search_games, update_game,
-    update_game_properties, manual_add_game, manual_remove_game, umu_is_installed, install_umu,
+    update_game_properties, manual_add_game, manual_remove_game, umu_is_installed, install_umu, get_executables
 };
 use monarch_library::commands::{
     create_collection, delete_collection, get_collections, update_collection,
@@ -45,7 +45,9 @@ fn init() {
 
     // Set initial monarch state
     unsafe {
-        MONARCH_STATE.set_library_games(&crate::monarch_games::monarch_client::get_library());
+        if let Err(e) = MONARCH_STATE.set_library_games(&crate::monarch_games::monarch_client::get_library()) {
+            panic!("init() Failed to set library games in state! | Err: {e}")
+        }
     }
 
     housekeeping::start(); // Starts housekeeping loop
@@ -102,6 +104,7 @@ fn main() {
             zoom_window,
             umu_is_installed,
             install_umu,
+            get_executables,
         ])
         .setup(|app| {
             #[cfg(desktop)]

--- a/src-tauri/src/monarch_games/commands.rs
+++ b/src-tauri/src/monarch_games/commands.rs
@@ -334,6 +334,8 @@ pub fn install_umu() -> Result<(), String> {
     }
 
     #[cfg(not(target_os = "linux"))]
-    warn!("Attempted to download umu-launcher under something other than Linux!");
-    return Err(format!("Can only use umu-launcher under Linux!"))
+    {
+        warn!("Attempted to download umu-launcher under something other than Linux!");
+        return Err(format!("Can only use umu-launcher under Linux!"))
+    }
 }

--- a/src-tauri/src/monarch_games/commands.rs
+++ b/src-tauri/src/monarch_games/commands.rs
@@ -305,3 +305,35 @@ pub async fn manual_remove_game(game: MonarchGame) -> Result<(), String> {
 
     return Ok(())
 }
+
+#[tauri::command]
+pub fn umu_is_installed() -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        use super::linux::umu;
+        return umu::umu_is_installed()
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    false
+}
+
+#[tauri::command]
+pub fn install_umu() -> Result<(), String> {
+    #[cfg(target_os = "linux")]
+    {
+        use super::linux::umu;
+        info!("Downloading umu-launcher...");
+
+        if let Err(e) = umu::install_umu() {
+            error!("monarch_games::commands::install_umu() -> {}", e.chain().map(|e| e.to_string()).collect::<String>());
+            return Err(format!("Failed to download umu-launcher!"))
+        }
+
+        return Ok(())
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    warn!("Attempted to download umu-launcher under something other than Linux!");
+    return Err(format!("Can only use umu-launcher under Linux!"))
+}

--- a/src-tauri/src/monarch_games/commands.rs
+++ b/src-tauri/src/monarch_games/commands.rs
@@ -375,6 +375,7 @@ pub fn install_umu() -> Result<(), String> {
 
     #[cfg(not(target_os = "linux"))]
     {
+        use tracing::warn;
         warn!("Attempted to download umu-launcher under something other than Linux!");
         return Err(format!("Can only use umu-launcher under Linux!"))
     }

--- a/src-tauri/src/monarch_games/linux/mod.rs
+++ b/src-tauri/src/monarch_games/linux/mod.rs
@@ -1,1 +1,2 @@
 pub mod steam;
+pub mod umu;

--- a/src-tauri/src/monarch_games/linux/umu.rs
+++ b/src-tauri/src/monarch_games/linux/umu.rs
@@ -1,0 +1,55 @@
+use anyhow::{bail, Result};
+use reqwest::Response;
+use serde::Deserialize;
+use std::path::PathBuf;
+
+use crate::monarch_utils::monarch_fs::get_monarch_home;
+
+#[derive(Debug, Deserialize)]
+struct Release {
+    tag_name: String,
+    assets: Vec<Asset>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Asset {
+    name: String,
+    browser_download_url: String,
+}
+
+/// Returns path where Monarch stores its copy of the umu-launcher binary.
+fn get_umu_path() -> PathBuf {
+    let path = get_monarch_home();
+    path.join("umu")
+}
+
+/// For now a simple check to verify that umu-launcher exists.
+fn umu_is_installed() -> bool {
+    get_umu_path().exists()
+}
+
+/// Installs the umu-launcher by downloading the binary to $MONARCH_HOME/umu/umu-run
+pub async fn install_umu() -> Result<()> {
+    if umu_is_installed() {
+        bail!("linux::umu::install_umu() Failed to install umu-launcher! | Err: Umu path already exists.")
+    }
+
+    let umu_release_url: &str =
+        "https://api.github.com/repos/Open-Wine-Components/umu-launcher/releases/latest/";
+
+    let release_response: String = reqwest::get(umu_release_url).await?.text().await?;
+    let release_data: Release = serde_json::from_str(&release_response)?;
+
+    let asset = release_data
+        .assets
+        .into_iter()
+        .find(|a| a.name.contains("zipapp") && a.name.ends_with(".tar"))
+        .ok_or("No matching asset found")
+        .unwrap();
+
+    let mut download_response: Response = reqwest::get(asset.browser_download_url).await?;
+    let mut dest = std::fs::File::create(&get_umu_path()).unwrap();
+    std::io::copy(&mut download_response, &mut dest).unwrap();
+
+    Ok(())
+}

--- a/src-tauri/src/monarch_games/linux/umu.rs
+++ b/src-tauri/src/monarch_games/linux/umu.rs
@@ -1,55 +1,91 @@
-use anyhow::{bail, Result};
-use reqwest::Response;
+use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 use std::path::PathBuf;
+use reqwest;
+use tracing::info;
+use tar::Archive;
 
 use crate::monarch_utils::monarch_fs::get_monarch_home;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 struct Release {
     tag_name: String,
     assets: Vec<Asset>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 struct Asset {
     name: String,
     browser_download_url: String,
 }
 
 /// Returns path where Monarch stores its copy of the umu-launcher binary.
-fn get_umu_path() -> PathBuf {
+fn get_umu_dir() -> PathBuf {
     let path = get_monarch_home();
     path.join("umu")
 }
 
+pub fn get_umu_exe() -> PathBuf {
+    get_umu_dir().join("umu-run")
+}
+
 /// For now a simple check to verify that umu-launcher exists.
-fn umu_is_installed() -> bool {
-    get_umu_path().exists()
+pub fn umu_is_installed() -> bool {
+    let umu_path = get_umu_dir();
+    if !umu_path.exists() {
+        return false
+    }
+    umu_path.join("umu-run").exists()
 }
 
 /// Installs the umu-launcher by downloading the binary to $MONARCH_HOME/umu/umu-run
-pub async fn install_umu() -> Result<()> {
+pub fn install_umu() -> Result<()> {
     if umu_is_installed() {
         bail!("linux::umu::install_umu() Failed to install umu-launcher! | Err: Umu path already exists.")
     }
 
+    info!("Getting umu-launcher releases...");
     let umu_release_url: &str =
-        "https://api.github.com/repos/Open-Wine-Components/umu-launcher/releases/latest/";
+        "https://api.github.com/repos/Open-Wine-Components/umu-launcher/releases";
 
-    let release_response: String = reqwest::get(umu_release_url).await?.text().await?;
-    let release_data: Release = serde_json::from_str(&release_response)?;
+    let client = reqwest::blocking::Client::new();
+    let release_response = client
+        .get(umu_release_url)
+        .header("User-Agent", "Monarch/1.0")
+        .send()?; 
 
-    let asset = release_data
+    let release_text: String = release_response.text()
+        .with_context(|| "linux::umu::install_umu() Failed to get response text from umu-launcher release page! | Err: ")?;
+
+    let release_data: Vec<Release> = serde_json::from_str(&release_text).with_context(|| "linux::umu::install_umu() Failed to parse response from umu-launcher release page! | Err: ")?;
+
+    info!("Using release: {}", release_data[0].tag_name);
+
+    let asset = release_data[0]
+        .clone()
         .assets
         .into_iter()
         .find(|a| a.name.contains("zipapp") && a.name.ends_with(".tar"))
         .ok_or("No matching asset found")
         .unwrap();
 
-    let mut download_response: Response = reqwest::get(asset.browser_download_url).await?;
-    let mut dest = std::fs::File::create(&get_umu_path()).unwrap();
-    std::io::copy(&mut download_response, &mut dest).unwrap();
+    info!("Downloading asset: {}...", asset.name);
+
+    let mut download_response = reqwest::blocking::get(&asset.browser_download_url).with_context(|| format!("linux::umu::install_umu() Failed to get response from {} | Err: ", &asset.browser_download_url))?;
+    let dest_path: PathBuf = get_monarch_home().join(asset.name);
+    let mut dest = std::fs::File::create(&dest_path).with_context(|| format!("linux::umu::install_umu() Failed to create: {} | Err: ", get_umu_dir().display()))?;
+
+    info!("Writing umu-launcher to: {}...", dest_path.display());
+    std::io::copy(&mut download_response, &mut dest).with_context(|| "linux::umu::install_umu() Failed to copy response to file! | Err: ")?;
+
+    info!("Unpacking: {}...", dest_path.display());
+    let mut archive = Archive::new(std::fs::File::open(&dest_path).with_context(|| format!("linux::umu::install_umu() Failed to open {} | Err: ", dest_path.display()))?);
+    archive.unpack(get_monarch_home()).with_context(|| format!("linux::umu::install_umu() Failed to unpack {}! | Err: ", dest_path.display()))?;
+
+    info!("Finished downloading umu-launcher.");
+
+    info!("Removing: {}...", dest_path.display());
+    std::fs::remove_file(&dest_path).with_context(|| format!("linux::umu::install_umu() Failed to remove: {} | Err: ", dest_path.display()))?;
 
     Ok(())
 }

--- a/src-tauri/src/monarch_games/monarchgame.rs
+++ b/src-tauri/src/monarch_games/monarchgame.rs
@@ -16,6 +16,9 @@ pub struct MonarchGame {
     pub launch_args: String,
     pub compatibility: String,
     pub store_page: String,
+
+    #[serde(default)]
+    pub install_dir: String,
 }
 
 impl MonarchGame {
@@ -38,6 +41,7 @@ impl MonarchGame {
             launch_args: String::new(),
             compatibility: String::new(),
             store_page: store_page.to_string(),
+            install_dir: String::new(),
         }
     }
 
@@ -81,6 +85,7 @@ impl MonarchGame {
             launch_args: "".to_string(),
             compatibility: "".to_string(),
             store_page: other.store_page.to_string(),
+            install_dir: "".to_string(),
         }
     }
 }

--- a/src-tauri/src/monarch_library/games_library.rs
+++ b/src-tauri/src/monarch_library/games_library.rs
@@ -3,6 +3,7 @@ use serde_json::{json, value::Value};
 use std::fs;
 use std::fs::File;
 use std::path::PathBuf;
+use tracing::error;
 
 use crate::monarch_games::monarchgame::MonarchGame;
 use crate::monarch_utils::monarch_fs::{
@@ -93,7 +94,9 @@ pub fn add_game(game: &MonarchGame) -> Result<()> {
         games = MONARCH_STATE.get_library_games();
         games.push(game.clone());
 
-        MONARCH_STATE.set_library_games(&games);
+        if let Err(e) = MONARCH_STATE.set_library_games(&games) {
+            error!("games_library::add_game() -> {}", e.chain().map(|e| e.to_string()).collect::<String>());
+        }
     }
 
     write_monarchgame(game)
@@ -112,7 +115,9 @@ pub fn remove_game(game: &MonarchGame) -> Result<()> {
             }
         }
 
-        MONARCH_STATE.set_library_games(&games);
+        if let Err(e) = MONARCH_STATE.set_library_games(&games) {
+            error!("games_library::remove_game() -> {}", e.chain().map(|e| e.to_string()).collect::<String>());
+        }
     }
 
     let mut monarch_games = get_monarchgames().with_context(|| "games_library::remove_game() -> ")?;
@@ -148,5 +153,5 @@ pub fn update_game_properties(game: &MonarchGame) -> Result<()> {
             .update_game(&game)
             .with_context(|| "games_library::update_game_properties() -> ")?;
     }
-    write_games(&games)
+    Ok(())
 }

--- a/src-tauri/src/monarch_utils/monarch_fs.rs
+++ b/src-tauri/src/monarch_utils/monarch_fs.rs
@@ -150,6 +150,34 @@ pub fn create_dir(path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Returns all found executables in a given directory
+pub fn get_executables(path: &Path) -> Result<Vec<PathBuf>> {
+    let mut executables: Vec<PathBuf> = Vec::new();
+    let executable_extensions: [&'static str; 6] = ["exe", "app", "sh", "bin", "run", "x86_64"];
+
+    visit_dir(&path, &mut executables, &executable_extensions).unwrap();
+
+    // Recursively visits all directories and subdirectories to find executables
+    fn visit_dir(path: &Path, executables: &mut Vec<PathBuf>, executable_extensions: &[&str]) -> Result<()> {
+        for entry in fs::read_dir(path).with_context(|| format!("monarch_fs::get_executables() Something went wrong trying to read directory: {dir} | Err: ", dir = path.display()))? {
+            let entry = entry.with_context(|| format!("monarch_fs::get_executables() Something went wrong trying to read directory entry: {dir} | Err: ", dir = path.display()))?;
+            let inner_path = entry.path();
+
+            if inner_path.is_file() {
+                if executable_extensions.contains(&inner_path.extension().unwrap_or("".as_ref()).to_str().unwrap_or("")) {
+                    executables.push(inner_path.clone());
+                }
+            }
+            if inner_path.is_dir() {
+                visit_dir(&inner_path, executables, executable_extensions)?;
+            }
+        }
+        Ok(())
+    }
+
+    Ok(executables)
+}
+
 /*
 ---------- Functions related to storing in resources dir ----------
 */

--- a/src-tauri/src/monarch_utils/monarch_fs.rs
+++ b/src-tauri/src/monarch_utils/monarch_fs.rs
@@ -210,7 +210,12 @@ pub fn is_in_cache_dir(path: &Path) -> bool {
 /// Returns path to new image in resources directory
 pub fn copy_cache_to_library(cache_path: &Path) -> Result<PathBuf> {
     let resources_path: PathBuf = get_resources_library();
-    let filename = cache_path.file_name().with_context(|| format!("monarch_fs::copy_cache_to_resources() Failed to get filename of path: {} | Err: ", cache_path.display()))?;
+    let filename = cache_path.file_name().with_context(|| {
+        format!(
+            "monarch_fs::copy_cache_to_resources() Failed to get filename of path: {} | Err: ",
+            cache_path.display()
+        )
+    })?;
     let destination_path = resources_path.join(&filename);
     fs::copy(cache_path, &destination_path)
         .with_context(|| format!("monarch_fs::copy_cache_to_resources() Something went wrong trying to copy image from cache to resources: {} | Err: {}", cache_path.display(), destination_path.display()))?;

--- a/src-tauri/src/monarch_utils/monarch_terminal.rs
+++ b/src-tauri/src/monarch_utils/monarch_terminal.rs
@@ -34,7 +34,7 @@ static APPSTATE: Lazy<Arc<AsyncMutex<Option<AppState>>>> = Lazy::new(|| Arc::new
 pub async fn run_in_terminal(
     handle: &AppHandle,
     command: &str,
-    env_vars: Option<HashMap<&str, &str>>,
+    env_vars: Option<&HashMap<&str, &str>>,
 ) -> Result<()> {
     info!("Starting Monarch terminal...");
 

--- a/src-tauri/src/monarch_utils/monarch_vdf.rs
+++ b/src-tauri/src/monarch_utils/monarch_vdf.rs
@@ -81,7 +81,8 @@ pub fn get_proton_versions(libraryfolders_vdf: &Path) -> Result<Vec<ProtonVersio
     let folders: LibraryFolders = LibraryFolders::read(libraryfolders_vdf)
         .with_context(|| "monarch_vdf::get_proton_versions() -> ")?;
 
-    let mut proton_versions: Vec<ProtonVersion> = Vec::new();
+    let mut proton_versions: Vec<ProtonVersion> = vec![ProtonVersion{name: "Proton-GE-Latest".to_string(), path: "GE-Proton".to_string()},
+                                                       ProtonVersion{name: "UMU-Proton".to_string(), path: "UMU-Proton".to_string()}];
 
     for (_, folder) in folders.0 {
         let path = PathBuf::from(folder.path).join("steamapps").join("common");

--- a/src/global/types/index.ts
+++ b/src/global/types/index.ts
@@ -8,6 +8,7 @@ export type MonarchGame = {
   store_page: string;
   compatibility: string;
   launch_args: string;
+  install_dir: string;
 };
 
 export type Result = {

--- a/src/pages/library/addGameManually/modal.tsx
+++ b/src/pages/library/addGameManually/modal.tsx
@@ -271,6 +271,7 @@ export default ({ opened, close, selectedFilePath, onGameAdded }: Props) => {
       store_page: '',
       compatibility: '',
       launch_args: '',
+      install_dir: '',
     };
 
     // Add game to frontend library immediately for instant feedback

--- a/src/pages/library/index.tsx
+++ b/src/pages/library/index.tsx
@@ -25,6 +25,7 @@ const LibraryContainer = styled.div`
   overflow-y: auto;
   border-radius: 0.5rem;
   margin: 1rem 0;
+  padding: 0 1rem; /* add horizontal gutters */
 `;
 
 const StyledRefreshIcon = styled(FiRefreshCcw)<{ $loading: boolean }>`
@@ -71,8 +72,8 @@ const UmuNoticeBar = styled.div`
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  padding: 0.75rem 1rem;
-  margin: 0 0 1rem 0;
+  padding: 0.75rem 1.5rem 0.75rem 1rem;
+  margin: 0 1rem 1rem 1rem;
   border-radius: 0.5rem;
   background: rgba(255, 193, 7, 0.1);
   border: 1px solid rgba(255, 193, 7, 0.35);

--- a/src/pages/library/index.tsx
+++ b/src/pages/library/index.tsx
@@ -9,6 +9,7 @@ import { useLibrary } from '@global/contexts/libraryProvider';
 import { FaFolderOpen, FaFolderPlus, FiRefreshCcw } from '@global/icons';
 import type { MonarchGame } from '@global/types';
 import { useDisclosure } from '@mantine/hooks';
+import { invoke } from '@tauri-apps/api/core';
 import * as dialog from '@tauri-apps/plugin-dialog';
 import * as React from 'react';
 import { flushSync } from 'react-dom';
@@ -17,7 +18,6 @@ import styled, { css } from 'styled-components';
 import AddGameModal from './addGameManually/modal';
 import Modal from './createCollection/modal';
 import Collection from './showCollection/collection';
-import { invoke } from '@tauri-apps/api/core';
 
 const LibraryContainer = styled.div`
   width: 100%;
@@ -143,6 +143,7 @@ const Library = () => {
       }
     };
     checkUmu();
+    // eslint-disable-next-line consistent-return
     return () => {
       cancelled = true;
     };
@@ -269,7 +270,7 @@ const Library = () => {
                     flushSync(() => setUmuInstalling(true));
                     // Force a paint before starting installation (more reliable on WebKitGTK)
                     await new Promise<void>((resolve) =>
-                      requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+                      { requestAnimationFrame(() => requestAnimationFrame(() => resolve())) },
                     );
                     await invoke('install_umu');
                     setShowUmuNotice(false);

--- a/src/pages/library/index.tsx
+++ b/src/pages/library/index.tsx
@@ -11,11 +11,13 @@ import type { MonarchGame } from '@global/types';
 import { useDisclosure } from '@mantine/hooks';
 import * as dialog from '@tauri-apps/plugin-dialog';
 import * as React from 'react';
+import { flushSync } from 'react-dom';
 import styled, { css } from 'styled-components';
 
 import AddGameModal from './addGameManually/modal';
 import Modal from './createCollection/modal';
 import Collection from './showCollection/collection';
+import { invoke } from '@tauri-apps/api/core';
 
 const LibraryContainer = styled.div`
   width: 100%;
@@ -64,6 +66,23 @@ const Sidebar = styled.div`
   gap: 1.5rem;
 `;
 
+const UmuNoticeBar = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  margin: 0 0 1rem 0;
+  border-radius: 0.5rem;
+  background: rgba(255, 193, 7, 0.1);
+  border: 1px solid rgba(255, 193, 7, 0.35);
+`;
+
+const UmuNoticeText = styled.p`
+  margin: 0;
+  font-size: 0.95rem;
+`;
+
 const StackedButton = styled(Button)`
   height: 3.5rem;
   font-size: 1rem;
@@ -95,6 +114,39 @@ const Library = () => {
   >();
   const { library, loading, error, refreshLibrary, results } = useLibrary();
   const { collections } = useCollections();
+
+  // umu-launcher notification state (Linux only)
+  const [showUmuNotice, setShowUmuNotice] = React.useState(false);
+  const [umuChecking, setUmuChecking] = React.useState(true);
+  const [umuInstalling, setUmuInstalling] = React.useState(false);
+
+  React.useEffect(() => {
+    // Only run under Linux
+    const isLinux = navigator.userAgent.toLowerCase().includes('linux');
+    if (!isLinux) {
+      setUmuChecking(false);
+      return;
+    }
+
+    let cancelled = false;
+    const checkUmu = async () => {
+      try {
+        const installed = await invoke<boolean>('umu_is_installed');
+        if (!cancelled) {
+          setShowUmuNotice(!installed);
+        }
+      } catch (err) {
+        // On error, be non-intrusive: hide the notice and optionally log
+        if (!cancelled) setShowUmuNotice(false);
+      } finally {
+        if (!cancelled) setUmuChecking(false);
+      }
+    };
+    checkUmu();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const handleOpenDialog = React.useCallback(async () => {
     try {
@@ -202,6 +254,38 @@ const Library = () => {
           />
         </Sidebar>
         <LibraryContainer>
+          {showUmuNotice && !umuChecking && (
+            <UmuNoticeBar>
+              <UmuNoticeText>
+                UMU Launcher is not installed. Some features may require it.
+              </UmuNoticeText>
+              <Button
+                type="button"
+                variant="primary"
+                loading={umuInstalling}
+                onClick={async () => {
+                  try {
+                    // Flush state synchronously so the label updates immediately
+                    flushSync(() => setUmuInstalling(true));
+                    // Force a paint before starting installation (more reliable on WebKitGTK)
+                    await new Promise<void>((resolve) =>
+                      requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+                    );
+                    await invoke('install_umu');
+                    setShowUmuNotice(false);
+                  } catch (err) {
+                    await dialog.message(`Failed to install umu-launcher: ${err}`, {
+                      title: 'Error',
+                    });
+                  } finally {
+                    setUmuInstalling(false);
+                  }
+                }}
+              >
+                {umuInstalling ? 'Downloading...' : 'Download umu-launcher'}
+              </Button>
+            </UmuNoticeBar>
+          )}
           {collections.length !== 0 && (
             <>
               {collections.map((collection) => (


### PR DESCRIPTION
This is merely an initial integration of umu-launcher into Monarch.

Currently it:
 - Looks for an `umu-run` binary in Monarchs share/appdata folder.
 - Downloads umu-launcher if needed.
 - Performs basic umu-run command to launch games with specified binary path and proton version.

Also improved binary selection by having Monarch scan the installation directory for executables of the game user wants to change properties of.